### PR TITLE
Add admin dashboard and infrastructure for portfolio management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Hildas-Website
 Github for my website serving my CV and stuff
+
+## Admin dashboard & infrastructure
+
+* `src/admin.html` + `src/admin.js` provide a dashboard to create, edit, and delete portfolio projects, including direct image uploads.
+* `infrastructure/template.yaml` contains an AWS SAM stack (API Gateway, Lambda, DynamoDB, S3) that powers the admin dashboard. See `infrastructure/README.md` for deployment steps.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,90 @@
+# Serverless infrastructure for the portfolio admin
+
+This folder contains an AWS SAM template that provisions everything required to manage portfolio items (projects) from the new admin dashboard:
+
+* **Amazon API Gateway** – exposes REST endpoints for CRUD operations and presigned S3 uploads.
+* **AWS Lambda (Node.js 18)** – business logic that stores portfolio entries in DynamoDB and issues signed upload URLs.
+* **Amazon DynamoDB** – persists portfolio item metadata (title, summary, link, tags, image key, timestamps).
+* **Amazon S3** – stores uploaded project images with CORS enabled for direct browser uploads.
+
+## Prerequisites
+
+1. [Install the AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) and ensure Docker is available if you plan to run local tests.
+2. Configure AWS credentials (`aws configure`) with permissions to deploy CloudFormation stacks, create Lambda functions, API Gateway stages, DynamoDB tables, and S3 buckets.
+3. Clone this repository locally.
+
+## Deploying
+
+You can deploy the stack in two commands. From the project root:
+
+```bash
+sam validate --template-file infrastructure/template.yaml
+sam deploy \
+  --template-file infrastructure/template.yaml \
+  --stack-name hilda-portfolio-stack \
+  --resolve-s3 \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    ProjectName=hilda-portfolio \
+    AdminApiKey=YOUR_STRONG_SHARED_SECRET \
+    AllowedOrigins="https://your-site.example,https://admin.your-site.example"
+```
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `ProjectName` | Prefix added to named resources. Helps keep things grouped. |
+| `AdminApiKey` | Shared secret required in the `x-admin-key` header for any create/update/delete/upload requests. Leave blank only if you plan to protect the API another way. |
+| `AllowedOrigins` | Comma-separated list of origins allowed to call the API and upload directly to S3. Include both your public site and the admin dashboard origin. Use `*` only for testing. |
+
+After a successful deployment SAM prints outputs similar to:
+
+```
+Outputs
+-------------------------------------------------------------------------------------
+Key                 ApiEndpoint                Value
+ApiEndpoint         https://xxxxxx.execute-api.us-east-1.amazonaws.com/prod
+ItemsTableName      hilda-portfolio-stack-PortfolioTable-...
+MediaBucketName     hilda-portfolio-stack-mediabucket-...
+MediaBucketUrl      https://hilda-portfolio-stack-mediabucket-....s3.us-east-1.amazonaws.com
+-------------------------------------------------------------------------------------
+```
+
+Copy the `ApiEndpoint` and `MediaBucketUrl` values for the front-end configuration.
+
+## Connecting the front end
+
+1. Host the static site (e.g., S3 + CloudFront, Amplify, Vercel, Netlify, etc.).
+2. Before serving `admin.html`, inject a small configuration block **above** the `<script src="admin.js">` tag:
+
+   ```html
+   <script>
+     window.PORTFOLIO_API_BASE = 'https://xxxxxx.execute-api.us-east-1.amazonaws.com/prod';
+     window.PORTFOLIO_MEDIA_BASE = 'https://hilda-portfolio-stack-mediabucket-123456.s3.us-east-1.amazonaws.com';
+     window.PORTFOLIO_ADMIN_KEY = 'YOUR_STRONG_SHARED_SECRET';
+   </script>
+   ```
+
+   For production, prefer serving the admin dashboard behind an authenticated channel (e.g., VPN, SSO portal, AWS Cognito). Avoid committing the admin key in version control.
+
+3. For the public `index.html`, you can optionally inject the first two lines (API base and media base) before the closing `</body>` tag if you want to pull dynamic projects instead of the static fallback.
+
+4. Open `admin.html`, click **Refresh**, and start creating projects. Uploaded images land in the S3 bucket provisioned by the template and are referenced automatically on the public site.
+
+## Regenerating the stack
+
+To update infrastructure changes:
+
+```bash
+sam build --template-file infrastructure/template.yaml
+sam deploy --guided
+```
+
+To remove everything when finished:
+
+```bash
+sam delete --stack-name hilda-portfolio-stack
+```
+
+This deletes the Lambda function, API Gateway stage, DynamoDB table, and S3 bucket (after you empty it or confirm force deletion).

--- a/infrastructure/functions/portfolio/handler.js
+++ b/infrastructure/functions/portfolio/handler.js
@@ -1,0 +1,315 @@
+const AWS = require('aws-sdk');
+const { v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
+const path = require('path');
+
+const ddb = new AWS.DynamoDB.DocumentClient();
+const s3 = new AWS.S3({ signatureVersion: 'v4' });
+
+const {
+  TABLE_NAME,
+  BUCKET_NAME,
+  MEDIA_PREFIX = 'projects',
+  MEDIA_BASE_URL = '',
+  ADMIN_API_KEY = '',
+  ALLOWED_ORIGIN = '*'
+} = process.env;
+
+const allowedOrigins = (ALLOWED_ORIGIN || '*')
+  .split(',')
+  .map(value => value.trim())
+  .filter(Boolean);
+
+function pickOrigin(requestOrigin){
+  if (allowedOrigins.includes('*')) return '*';
+  if (!requestOrigin) return allowedOrigins[0] || '*';
+  return allowedOrigins.includes(requestOrigin) ? requestOrigin : allowedOrigins[0];
+}
+
+function buildResponse(statusCode, body, origin){
+  return {
+    statusCode,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': origin || '*',
+      'Access-Control-Allow-Credentials': 'false',
+      'Access-Control-Allow-Headers': 'Content-Type,X-Admin-Key',
+      'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS'
+    },
+    body: body ? JSON.stringify(body) : ''
+  };
+}
+
+function parseBody(event){
+  if (!event.body) return {};
+  if (typeof event.body === 'string') {
+    try {
+      return JSON.parse(event.body);
+    } catch (err) {
+      throw new HttpError(400, 'Invalid JSON body');
+    }
+  }
+  return event.body;
+}
+
+function sanitizeString(value, maxLength){
+  if (value === undefined || value === null) return undefined;
+  const str = String(value).trim();
+  if (!str) return '';
+  return str.slice(0, maxLength || 500);
+}
+
+function sanitizeUrl(value){
+  if (!value) return undefined;
+  const str = String(value).trim();
+  if (!str) return undefined;
+  if (!/^https?:\/\//i.test(str)) return undefined;
+  return str.slice(0, 500);
+}
+
+function normalizeTags(value){
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.map(v => sanitizeTag(v)).filter(Boolean);
+  }
+  return String(value)
+    .split(',')
+    .map(part => sanitizeTag(part))
+    .filter(Boolean);
+}
+
+function sanitizeTag(value){
+  if (!value && value !== 0) return '';
+  const str = String(value).trim();
+  if (!str) return '';
+  return str.replace(/[^a-z0-9\- ]/gi, '').replace(/\s+/g, '-').slice(0, 40).toLowerCase();
+}
+
+function sanitizeKey(value){
+  if (value === undefined || value === null) return value;
+  const str = String(value).trim();
+  return str.replace(/^\/+/, '');
+}
+
+function requireAdmin(event, origin){
+  if (!ADMIN_API_KEY) return null;
+  const provided = (event.headers?.['x-admin-key'] || event.headers?.['X-Admin-Key'] || '').trim();
+  if (provided !== ADMIN_API_KEY) {
+    return buildResponse(401, { message: 'Unauthorized' }, origin);
+  }
+  return null;
+}
+
+class HttpError extends Error {
+  constructor(statusCode, message){
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+async function listItems(){
+  const data = await ddb.scan({ TableName: TABLE_NAME }).promise();
+  const items = (data.Items || []).map(mapItem).sort((a, b) => {
+    const left = new Date(a.createdAt || 0).valueOf();
+    const right = new Date(b.createdAt || 0).valueOf();
+    if (!Number.isFinite(left) || !Number.isFinite(right)) return 0;
+    return right - left;
+  });
+  return items;
+}
+
+function mapItem(item){
+  if (!item) return item;
+  const mapped = { ...item };
+  if (MEDIA_BASE_URL && item.imageKey && !item.imageUrl) {
+    mapped.imageUrl = `${MEDIA_BASE_URL.replace(/\/+$/, '')}/${item.imageKey.replace(/^\/+/, '')}`;
+  }
+  return mapped;
+}
+
+async function createItem(payload){
+  const now = new Date().toISOString();
+  const item = {
+    id: uuidv4(),
+    title: sanitizeString(payload.title, 200) || 'Untitled project',
+    summary: sanitizeString(payload.summary, 600) || '',
+    link: sanitizeUrl(payload.link),
+    tags: normalizeTags(payload.tags),
+    featured: Boolean(payload.featured),
+    imageKey: sanitizeKey(payload.imageKey) || null,
+    imageAlt: sanitizeString(payload.imageAlt, 120) || null,
+    createdAt: now,
+    updatedAt: now
+  };
+
+  if (!item.summary) {
+    throw new HttpError(400, 'Summary is required.');
+  }
+
+  await ddb.put({
+    TableName: TABLE_NAME,
+    Item: item
+  }).promise();
+
+  return mapItem(item);
+}
+
+async function updateItem(id, payload){
+  if (!id) throw new HttpError(400, 'Missing item id');
+  const now = new Date().toISOString();
+  const updates = {};
+
+  if (payload.title !== undefined) updates.title = sanitizeString(payload.title, 200) || 'Untitled project';
+  if (payload.summary !== undefined) {
+    const summary = sanitizeString(payload.summary, 600) || '';
+    if (!summary) throw new HttpError(400, 'Summary is required.');
+    updates.summary = summary;
+  }
+  if (payload.link !== undefined) updates.link = sanitizeUrl(payload.link) || null;
+  if (payload.tags !== undefined) updates.tags = normalizeTags(payload.tags);
+  if (payload.featured !== undefined) updates.featured = Boolean(payload.featured);
+  if (payload.imageKey !== undefined) updates.imageKey = sanitizeKey(payload.imageKey) || null;
+  if (payload.imageAlt !== undefined) updates.imageAlt = sanitizeString(payload.imageAlt, 120) || null;
+
+  if (Object.keys(updates).length === 0) {
+    throw new HttpError(400, 'No updates provided');
+  }
+
+  const updateExpressions = [];
+  const expressionAttributeNames = { '#updatedAt': 'updatedAt' };
+  const expressionAttributeValues = { ':updatedAt': now };
+  let index = 0;
+
+  for (const [key, value] of Object.entries(updates)) {
+    index += 1;
+    const nameKey = `#f${index}`;
+    const valueKey = `:v${index}`;
+    expressionAttributeNames[nameKey] = key;
+    expressionAttributeValues[valueKey] = value;
+    updateExpressions.push(`${nameKey} = ${valueKey}`);
+  }
+
+  const result = await ddb.update({
+    TableName: TABLE_NAME,
+    Key: { id },
+    UpdateExpression: `SET ${updateExpressions.join(', ')}, #updatedAt = :updatedAt`,
+    ExpressionAttributeNames: expressionAttributeNames,
+    ExpressionAttributeValues: expressionAttributeValues,
+    ReturnValues: 'ALL_NEW'
+  }).promise();
+
+  if (!result.Attributes) throw new HttpError(404, 'Item not found');
+  return mapItem(result.Attributes);
+}
+
+async function deleteItem(id){
+  if (!id) throw new HttpError(400, 'Missing item id');
+  const existing = await ddb.get({
+    TableName: TABLE_NAME,
+    Key: { id }
+  }).promise();
+
+  if (!existing.Item) throw new HttpError(404, 'Item not found');
+
+  await ddb.delete({
+    TableName: TABLE_NAME,
+    Key: { id }
+  }).promise();
+
+  if (existing.Item.imageKey) {
+    const key = existing.Item.imageKey;
+    try {
+      await s3.deleteObject({ Bucket: BUCKET_NAME, Key: key }).promise();
+    } catch (err) {
+      console.warn('Failed to delete image', key, err);
+    }
+  }
+}
+
+function sanitizeFilename(name){
+  const ext = path.extname(name || '').slice(0, 10);
+  const base = path.basename(name || 'upload', ext);
+  const cleanBase = base.replace(/[^a-z0-9\-]+/gi, '-').replace(/-{2,}/g, '-').replace(/^-|-$/g, '').toLowerCase() || 'upload';
+  return `${cleanBase}${ext.toLowerCase()}`;
+}
+
+async function createUploadUrl(id, filename, contentType){
+  if (!id) throw new HttpError(400, 'Missing item id');
+  if (!filename) throw new HttpError(400, 'Filename is required');
+
+  const safeName = sanitizeFilename(filename);
+  const hash = crypto.randomBytes(4).toString('hex');
+  const prefix = MEDIA_PREFIX.replace(/\/+$/, '');
+  const key = `${prefix}/${id}/${Date.now()}-${hash}-${safeName}`;
+
+  const uploadUrl = await s3.getSignedUrlPromise('putObject', {
+    Bucket: BUCKET_NAME,
+    Key: key,
+    ContentType: contentType || 'application/octet-stream',
+    Expires: 300,
+    ACL: 'public-read'
+  });
+
+  const publicUrl = MEDIA_BASE_URL
+    ? `${MEDIA_BASE_URL.replace(/\/+$/, '')}/${key}`
+    : `https://${BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+
+  return { uploadUrl, objectKey: key, publicUrl };
+}
+
+exports.handler = async (event) => {
+  const origin = pickOrigin(event.headers?.origin || event.headers?.Origin);
+
+  if (event.httpMethod === 'OPTIONS') {
+    return buildResponse(200, { ok: true }, origin);
+  }
+
+  try {
+    const path = event.resource || event.path;
+    const id = event.pathParameters?.id;
+
+    if (event.httpMethod === 'GET' && path === '/items') {
+      const items = await listItems();
+      return buildResponse(200, { items }, origin);
+    }
+
+    if (event.httpMethod === 'POST' && path === '/items') {
+      const authError = requireAdmin(event, origin);
+      if (authError) return authError;
+      const payload = parseBody(event);
+      const item = await createItem(payload);
+      return buildResponse(201, { item }, origin);
+    }
+
+    if (event.httpMethod === 'PUT' && path === '/items/{id}') {
+      const authError = requireAdmin(event, origin);
+      if (authError) return authError;
+      const payload = parseBody(event);
+      const item = await updateItem(id, payload);
+      return buildResponse(200, { item }, origin);
+    }
+
+    if (event.httpMethod === 'DELETE' && path === '/items/{id}') {
+      const authError = requireAdmin(event, origin);
+      if (authError) return authError;
+      await deleteItem(id);
+      return buildResponse(200, { success: true }, origin);
+    }
+
+    if (event.httpMethod === 'POST' && path === '/items/{id}/upload-url') {
+      const authError = requireAdmin(event, origin);
+      if (authError) return authError;
+      const payload = parseBody(event);
+      const result = await createUploadUrl(id, payload.filename, payload.contentType);
+      return buildResponse(200, result, origin);
+    }
+
+    throw new HttpError(404, 'Not found');
+  } catch (err) {
+    console.error('Request failed', err);
+    if (err instanceof HttpError) {
+      return buildResponse(err.statusCode || 500, { message: err.message }, origin);
+    }
+    return buildResponse(500, { message: 'Internal server error' }, origin);
+  }
+};

--- a/infrastructure/functions/portfolio/package.json
+++ b/infrastructure/functions/portfolio/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "portfolio-api",
+  "version": "1.0.0",
+  "description": "Serverless portfolio CRUD handler",
+  "main": "handler.js",
+  "license": "MIT",
+  "dependencies": {
+    "uuid": "^9.0.1"
+  }
+}

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1,0 +1,165 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Serverless portfolio backend for Hilda's website (projects CRUD + media uploads).
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: hilda-portfolio
+    Description: Prefix used for named resources such as the API.
+  AdminApiKey:
+    Type: String
+    NoEcho: true
+    Default: ''
+    Description: Shared secret required for admin mutations. Leave blank to disable (not recommended).
+  AllowedOrigins:
+    Type: String
+    Default: http://localhost:5173,https://localhost:5173
+    Description: Comma-separated list of allowed origins for CORS (API & S3 uploads). Use * for all origins.
+
+Globals:
+  Function:
+    Runtime: nodejs18.x
+    MemorySize: 256
+    Timeout: 30
+    Architectures:
+      - arm64
+    Environment:
+      Variables:
+        TABLE_NAME: !Ref PortfolioTable
+        BUCKET_NAME: !Ref MediaBucket
+        MEDIA_PREFIX: projects
+        MEDIA_BASE_URL: !Sub https://${MediaBucket}.s3.${AWS::Region}.amazonaws.com
+        ADMIN_API_KEY: !Ref AdminApiKey
+        ALLOWED_ORIGIN: !Ref AllowedOrigins
+
+Resources:
+  PortfolioApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      Name: !Sub ${ProjectName}-api
+      StageName: prod
+      Cors:
+        AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS'"
+        AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Admin-Key'"
+        AllowOrigins: !Sub "'${AllowedOrigins}'"
+      MethodSettings:
+        - LoggingLevel: INFO
+          MetricsEnabled: true
+          ResourcePath: '/*'
+          HttpMethod: '*'
+
+  PortfolioFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub ${ProjectName}-handler
+      Description: CRUD + signed upload URLs for portfolio items.
+      CodeUri: functions/portfolio/
+      Handler: handler.handler
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PortfolioTable
+        - S3CrudPolicy:
+            BucketName: !Ref MediaBucket
+      Events:
+        ListItems:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /items
+            Method: get
+        CreateItem:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /items
+            Method: post
+        UpdateItem:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /items/{id}
+            Method: put
+        DeleteItem:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /items/{id}
+            Method: delete
+        SignUpload:
+          Type: Api
+          Properties:
+            RestApiId: !Ref PortfolioApi
+            Path: /items/{id}/upload-url
+            Method: post
+      Tags:
+        Project: !Ref ProjectName
+
+  PortfolioTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectName
+
+  MediaBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerPreferred
+      CorsConfiguration:
+        CorsRules:
+          - AllowedHeaders: ['*']
+            AllowedMethods: ['GET', 'HEAD', 'PUT']
+            AllowedOrigins: !Split [',', !Ref AllowedOrigins]
+            ExposedHeaders: ['ETag']
+            MaxAge: 3600
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+      Tags:
+        - Key: Project
+          Value: !Ref ProjectName
+
+  MediaBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref MediaBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowPublicRead
+            Effect: Allow
+            Principal: '*'
+            Action: s3:GetObject
+            Resource: !Sub ${MediaBucket.Arn}/*
+
+Outputs:
+  ApiEndpoint:
+    Description: Invoke URL for the API Gateway stage.
+    Value: !Sub https://${PortfolioApi}.execute-api.${AWS::Region}.amazonaws.com/prod
+  ItemsTableName:
+    Description: DynamoDB table storing portfolio items.
+    Value: !Ref PortfolioTable
+  MediaBucketName:
+    Description: S3 bucket for project images.
+    Value: !Ref MediaBucket
+  MediaBucketUrl:
+    Description: Public base URL for uploaded images.
+    Value: !Sub https://${MediaBucket}.s3.${AWS::Region}.amazonaws.com

--- a/src/admin.html
+++ b/src/admin.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Portfolio Admin · Hilda Machando</title>
+  <meta name="color-scheme" content="light dark" />
+  <style>
+    :root {
+      --bg:#0b1020;
+      --panel:#101735;
+      --ink:#e6edf9;
+      --muted:#9aa5d3;
+      --accent:#3b82f6;
+      --accent-strong:#1d4ed8;
+      --danger:#f87171;
+      --success:#34d399;
+      --radius:18px;
+      --shadow:0 24px 60px rgba(2,6,23,.35);
+    }
+    @media (prefers-color-scheme: light){
+      :root {
+        --bg:#f8fafc;
+        --panel:#ffffff;
+        --ink:#0b1020;
+        --muted:#475569;
+        --shadow:0 18px 45px rgba(2,6,23,.1);
+      }
+    }
+    *{box-sizing:border-box}
+    html, body{height:100%}
+    body{
+      margin:0;
+      font:16px/1.55 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial;
+      background:
+        radial-gradient(900px 600px at 80% -10%, rgba(59,130,246,.18), transparent 60%),
+        radial-gradient(800px 500px at -10% 90%, rgba(236,72,153,.18), transparent 60%),
+        var(--bg);
+      color:var(--ink);
+      padding:32px 16px 40px;
+    }
+    .wrap{width:min(1100px, 96vw); margin:0 auto; display:grid; gap:24px}
+    header{display:flex; flex-wrap:wrap; justify-content:space-between; align-items:center; gap:1rem}
+    header h1{margin:0; font-size:clamp(1.4rem, 1.2vw + 1.1rem, 2rem);}
+    header p{margin:0; color:var(--muted); max-width:560px}
+    .panel{
+      background:var(--panel);
+      border-radius:var(--radius);
+      padding:22px;
+      border:1px solid rgba(255,255,255,.08);
+      box-shadow:var(--shadow);
+    }
+    form{display:grid; gap:16px}
+    .field{display:grid; gap:6px}
+    label{font-weight:700; font-size:.95rem}
+    input[type="text"], input[type="url"], textarea{
+      appearance:none;
+      border:1px solid rgba(255,255,255,.12);
+      border-radius:12px;
+      padding:.65rem .8rem;
+      font:inherit;
+      background:rgba(11,16,32,.35);
+      color:inherit;
+      box-shadow:inset 0 1px 0 rgba(255,255,255,.04);
+    }
+    input[type="file"]{color:inherit; font:inherit}
+    textarea{min-height:120px; resize:vertical}
+    .hint{margin:0; color:var(--muted); font-size:.9rem}
+    .checkbox{display:flex; align-items:center; gap:.6rem}
+    .checkbox label{font-weight:500}
+    .actions{display:flex; flex-wrap:wrap; gap:.6rem}
+    button{
+      appearance:none; border:0; cursor:pointer; font-weight:700;
+      padding:.65rem 1.1rem; border-radius:12px;
+      background:rgba(255,255,255,.12); color:inherit;
+      transition:filter .16s ease, transform .16s ease;
+    }
+    button.primary{background:linear-gradient(135deg, var(--accent), var(--accent-strong)); color:#fff;}
+    button.danger{background:rgba(248,113,113,.16); color:#fff; border:1px solid rgba(248,113,113,.45);}
+    button:hover{filter:brightness(1.05); transform:translateY(-1px)}
+    button:disabled{opacity:.6; cursor:not-allowed; transform:none}
+    .form-status{margin:0; font-weight:600; font-size:.95rem}
+    .form-status[data-type="error"]{color:var(--danger)}
+    .form-status[data-type="success"]{color:var(--success)}
+    .form-status[data-type="warning"]{color:#fbbf24}
+    .item-list{display:grid; gap:16px}
+    .item-card{
+      border:1px solid rgba(255,255,255,.1);
+      border-radius:16px;
+      padding:18px;
+      background:rgba(15,24,48,.55);
+      box-shadow:inset 0 1px 0 rgba(255,255,255,.04);
+      display:grid;
+      gap:12px;
+    }
+    .item-card-header{display:flex; flex-wrap:wrap; justify-content:space-between; gap:.6rem; align-items:center}
+    .item-card-actions{display:flex; gap:.4rem}
+    .item-card h3{margin:0; font-size:1.05rem}
+    .item-card p{margin:0; color:var(--muted)}
+    .item-card img{width:100%; max-height:220px; object-fit:cover; border-radius:12px; border:1px solid rgba(255,255,255,.08)}
+    .item-meta{font-size:.85rem; color:var(--muted)}
+    .pill{display:inline-flex; align-items:center; gap:.35rem; padding:.2rem .6rem; border-radius:999px; border:1px solid rgba(255,255,255,.12); font-size:.85rem; margin:.2rem .2rem 0 0}
+    .tag-row{display:flex; flex-wrap:wrap; gap:.35rem}
+    .empty{margin:0; color:var(--muted); font-style:italic}
+    .notice{margin:0; padding:14px; border-radius:14px; border:1px solid rgba(255,255,255,.1); background:rgba(59,130,246,.12);}
+    .notice strong{color:#fff}
+    #current-image-wrap{display:grid; gap:.6rem}
+    #current-image{max-width:260px; border-radius:12px; border:1px solid rgba(255,255,255,.1)}
+    .toolbar{display:flex; gap:.4rem; flex-wrap:wrap}
+    .toolbar button{padding:.45rem .8rem; font-size:.9rem}
+    .toolbar a.button-link{
+      display:inline-flex; align-items:center; justify-content:center;
+      padding:.45rem .8rem; border-radius:12px;
+      background:rgba(255,255,255,.12);
+      color:inherit; text-decoration:none; font-weight:700;
+      transition:filter .16s ease, transform .16s ease;
+    }
+    .toolbar a.button-link:hover{filter:brightness(1.05); transform:translateY(-1px)}
+    .item-card-actions{display:flex; gap:.4rem}
+    .loading{margin:0; color:var(--muted)}
+    @media (prefers-color-scheme: light){
+      input[type="text"], input[type="url"], textarea{background:rgba(255,255,255,.9); color:inherit}
+      .item-card{background:rgba(255,255,255,.9)}
+      button.danger{color:var(--danger)}
+      .notice strong{color:var(--accent-strong)}
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <div>
+        <h1>Portfolio Admin</h1>
+        <p>Manage the projects displayed on your public site. Configure the API endpoint and admin key before making changes.</p>
+      </div>
+      <div class="toolbar">
+        <button type="button" id="refresh-btn">⟳ Refresh</button>
+        <a href="index.html" class="button-link">← Back to site</a>
+      </div>
+    </header>
+
+    <p id="config-warning" class="notice" hidden>
+      <strong>Configuration needed.</strong> Set <code>window.PORTFOLIO_API_BASE</code> (and optionally <code>window.PORTFOLIO_MEDIA_BASE</code>) before this page loads. Example:
+      <br />
+      <code>&lt;script&gt;window.PORTFOLIO_API_BASE='https://xxxxx.execute-api.us-east-1.amazonaws.com/prod'; window.PORTFOLIO_ADMIN_KEY='YOUR-ADMIN-KEY'; window.PORTFOLIO_MEDIA_BASE='https://your-bucket.s3.amazonaws.com';&lt;/script&gt;</code>
+    </p>
+
+    <section class="panel">
+      <form id="item-form">
+        <h2 id="form-title">Create new portfolio item</h2>
+        <div class="field">
+          <label for="title">Title</label>
+          <input id="title" name="title" type="text" required maxlength="200" placeholder="e.g. Zero Trust Automation" />
+        </div>
+        <div class="field">
+          <label for="summary">Summary</label>
+          <textarea id="summary" name="summary" required maxlength="500" placeholder="Short description shown on the site."></textarea>
+        </div>
+        <div class="field">
+          <label for="link">External link</label>
+          <input id="link" name="link" type="url" placeholder="https://" />
+          <p class="hint">Optional link to the case study or repository.</p>
+        </div>
+        <div class="field">
+          <label for="tags">Tags</label>
+          <input id="tags" name="tags" type="text" placeholder="risk, automation, aws" />
+          <p class="hint">Comma-separated keywords. Displayed as badges.</p>
+        </div>
+        <div class="checkbox">
+          <label><input id="featured" name="featured" type="checkbox" /> Feature this project</label>
+        </div>
+        <div class="field">
+          <label for="image">Project image</label>
+          <input id="image" name="image" type="file" accept="image/*" />
+          <p class="hint">Upload to set or replace the image. Leave empty to keep the current image.</p>
+        </div>
+        <div id="current-image-wrap" hidden>
+          <p class="hint">Current image preview</p>
+          <img id="current-image" alt="Current project image" />
+        </div>
+        <div class="actions">
+          <button type="submit" class="primary" id="save-btn">Save item</button>
+          <button type="button" id="reset-btn">Reset</button>
+        </div>
+        <p id="form-status" class="form-status" hidden></p>
+      </form>
+    </section>
+
+    <section class="panel">
+      <h2>Published items</h2>
+      <p id="loading-state" class="loading">Connect to your API and click refresh.</p>
+      <p id="empty-state" class="empty" hidden>No portfolio items yet. Create one above.</p>
+      <div id="items-list" class="item-list" aria-live="polite"></div>
+    </section>
+  </div>
+
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/src/admin.js
+++ b/src/admin.js
@@ -1,0 +1,407 @@
+(function(){
+  const API_BASE = (window.PORTFOLIO_API_BASE || '').trim().replace(/\/+$/, '');
+  const MEDIA_BASE = (window.PORTFOLIO_MEDIA_BASE || '').trim().replace(/\/+$/, '');
+  const ADMIN_KEY = window.PORTFOLIO_ADMIN_KEY || '';
+
+  const form = document.getElementById('item-form');
+  const titleInput = document.getElementById('title');
+  const summaryInput = document.getElementById('summary');
+  const linkInput = document.getElementById('link');
+  const tagsInput = document.getElementById('tags');
+  const featuredInput = document.getElementById('featured');
+  const imageInput = document.getElementById('image');
+  const formStatus = document.getElementById('form-status');
+  const formTitle = document.getElementById('form-title');
+  const resetBtn = document.getElementById('reset-btn');
+  const saveBtn = document.getElementById('save-btn');
+  const currentImageWrap = document.getElementById('current-image-wrap');
+  const currentImage = document.getElementById('current-image');
+  const configWarning = document.getElementById('config-warning');
+  const loadingState = document.getElementById('loading-state');
+  const emptyState = document.getElementById('empty-state');
+  const listEl = document.getElementById('items-list');
+  const refreshBtn = document.getElementById('refresh-btn');
+
+  let editingId = null;
+  let items = [];
+
+  function setFormStatus(message, type){
+    if (!formStatus) return;
+    if (!message){
+      formStatus.textContent = '';
+      formStatus.hidden = true;
+      formStatus.removeAttribute('data-type');
+      return;
+    }
+    formStatus.textContent = message;
+    formStatus.dataset.type = type || 'info';
+    formStatus.hidden = false;
+  }
+
+  function disableForm(disabled){
+    if (!form) return;
+    form.querySelectorAll('input, textarea, button').forEach(el => {
+      if (!el) return;
+      el.disabled = disabled;
+    });
+  }
+
+  function normaliseTags(value){
+    if (!value) return [];
+    return value.split(',').map(t => t.trim()).filter(Boolean);
+  }
+
+  function formatDate(value){
+    if (!value) return '';
+    try {
+      const date = new Date(value);
+      if (Number.isNaN(date.valueOf())) return '';
+      return date.toLocaleString();
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function buildImageUrl(item){
+    if (!item) return '';
+    if (item.imageUrl) return item.imageUrl;
+    if (item.imageKey){
+      if (MEDIA_BASE) return `${MEDIA_BASE}/${item.imageKey}`;
+      return item.imageKey;
+    }
+    return '';
+  }
+
+  function renderItems(){
+    if (!listEl) return;
+    listEl.innerHTML = '';
+    if (!items.length){
+      if (emptyState) emptyState.hidden = false;
+      return;
+    }
+    if (emptyState) emptyState.hidden = true;
+    const frag = document.createDocumentFragment();
+    items.forEach(item => {
+      const card = document.createElement('article');
+      card.className = 'item-card';
+      card.dataset.id = item.id;
+      const header = document.createElement('div');
+      header.className = 'item-card-header';
+      const h3 = document.createElement('h3');
+      h3.textContent = item.title || 'Untitled project';
+      const actions = document.createElement('div');
+      actions.className = 'item-card-actions';
+      const editBtn = document.createElement('button');
+      editBtn.type = 'button';
+      editBtn.textContent = 'Edit';
+      editBtn.dataset.action = 'edit';
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.textContent = 'Delete';
+      deleteBtn.className = 'danger';
+      deleteBtn.dataset.action = 'delete';
+      actions.appendChild(editBtn);
+      actions.appendChild(deleteBtn);
+      header.appendChild(h3);
+      header.appendChild(actions);
+      card.appendChild(header);
+
+      const imageUrl = buildImageUrl(item);
+      if (imageUrl){
+        const img = document.createElement('img');
+        img.src = imageUrl;
+        img.alt = item.imageAlt || `${item.title || 'Project'} preview`;
+        card.appendChild(img);
+      }
+
+      if (item.summary){
+        const summary = document.createElement('p');
+        summary.textContent = item.summary;
+        card.appendChild(summary);
+      }
+
+      if (item.link){
+        const link = document.createElement('p');
+        const anchor = document.createElement('a');
+        anchor.href = item.link;
+        anchor.target = '_blank';
+        anchor.rel = 'noopener';
+        anchor.textContent = 'Open link →';
+        link.appendChild(anchor);
+        card.appendChild(link);
+      }
+
+      const meta = document.createElement('p');
+      meta.className = 'item-meta';
+      const created = formatDate(item.createdAt);
+      const updated = formatDate(item.updatedAt);
+      meta.textContent = `Created ${created || '—'} · Updated ${updated || created || '—'}`;
+      card.appendChild(meta);
+
+      const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean) : [];
+      if (tags.length){
+        const tagRow = document.createElement('div');
+        tagRow.className = 'tag-row';
+        tags.forEach(tag => {
+          const pill = document.createElement('span');
+          pill.className = 'pill';
+          pill.textContent = `#${tag}`;
+          tagRow.appendChild(pill);
+        });
+        card.appendChild(tagRow);
+      }
+
+      frag.appendChild(card);
+    });
+    listEl.appendChild(frag);
+  }
+
+  function setEditing(item){
+    if (!form) return;
+    editingId = item ? item.id : null;
+    if (!item){
+      form.reset();
+      if (currentImageWrap) {
+        currentImageWrap.hidden = true;
+        if (currentImage) currentImage.removeAttribute('src');
+      }
+      if (formTitle) formTitle.textContent = 'Create new portfolio item';
+      if (saveBtn) saveBtn.textContent = 'Save item';
+      return;
+    }
+    if (formTitle) formTitle.textContent = 'Edit portfolio item';
+    if (saveBtn) saveBtn.textContent = 'Update item';
+    titleInput.value = item.title || '';
+    summaryInput.value = item.summary || '';
+    linkInput.value = item.link || '';
+    tagsInput.value = Array.isArray(item.tags) ? item.tags.join(', ') : '';
+    featuredInput.checked = Boolean(item.featured);
+    imageInput.value = '';
+    const imageUrl = buildImageUrl(item);
+    if (imageUrl){
+      if (currentImage) currentImage.src = imageUrl;
+      if (currentImageWrap) currentImageWrap.hidden = false;
+    } else if (currentImageWrap){
+      currentImageWrap.hidden = true;
+      if (currentImage) currentImage.removeAttribute('src');
+    }
+    setFormStatus('', 'info');
+  }
+
+  function getHeaders(isJson){
+    const headers = {};
+    if (isJson) headers['Content-Type'] = 'application/json';
+    if (ADMIN_KEY) headers['x-admin-key'] = ADMIN_KEY;
+    return headers;
+  }
+
+  async function loadItems(showStatus){
+    if (!API_BASE){
+      if (configWarning) configWarning.hidden = false;
+      if (loadingState) loadingState.textContent = 'Configure window.PORTFOLIO_API_BASE to begin.';
+      return;
+    }
+    if (configWarning) configWarning.hidden = true;
+    if (loadingState) {
+      loadingState.textContent = 'Loading portfolio items…';
+      loadingState.hidden = false;
+    }
+    try {
+      const res = await fetch(`${API_BASE}/items`, {
+        method: 'GET',
+        headers: getHeaders(false)
+      });
+      if (!res.ok) throw new Error(`Failed to load items (${res.status})`);
+      const payload = await res.json();
+      items = Array.isArray(payload) ? payload : (payload.items || []);
+      renderItems();
+      if (loadingState) {
+        loadingState.textContent = '';
+        loadingState.hidden = true;
+      }
+      if (showStatus) setFormStatus('Latest data loaded.', 'success');
+    } catch (err) {
+      console.error(err);
+      if (loadingState) {
+        loadingState.textContent = 'Unable to load items. Check the API URL, admin key, and CORS settings.';
+        loadingState.hidden = false;
+      }
+      setFormStatus(err.message, 'error');
+    }
+  }
+
+  async function requestUpload(id, file){
+    const res = await fetch(`${API_BASE}/items/${encodeURIComponent(id)}/upload-url`, {
+      method: 'POST',
+      headers: getHeaders(true),
+      body: JSON.stringify({
+        filename: file.name,
+        contentType: file.type || 'application/octet-stream'
+      })
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Failed to get upload URL');
+    }
+    return res.json();
+  }
+
+  async function uploadImage(uploadUrl, file){
+    const res = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': file.type || 'application/octet-stream' },
+      body: file
+    });
+    if (!res.ok) throw new Error('Image upload failed.');
+  }
+
+  async function createItem(payload){
+    const res = await fetch(`${API_BASE}/items`, {
+      method: 'POST',
+      headers: getHeaders(true),
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Failed to create item');
+    }
+    return res.json();
+  }
+
+  async function updateItem(id, payload){
+    const res = await fetch(`${API_BASE}/items/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: getHeaders(true),
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Failed to update item');
+    }
+    return res.json();
+  }
+
+  async function deleteItem(id){
+    const res = await fetch(`${API_BASE}/items/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+      headers: getHeaders(false)
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text || 'Failed to delete item');
+    }
+    return res.json();
+  }
+
+  async function handleSubmit(event){
+    event.preventDefault();
+    if (!API_BASE){
+      setFormStatus('API base URL is not configured.', 'error');
+      return;
+    }
+    const title = titleInput.value.trim();
+    const summary = summaryInput.value.trim();
+    if (!title || !summary){
+      setFormStatus('Title and summary are required.', 'error');
+      return;
+    }
+    const payload = {
+      title,
+      summary,
+      link: linkInput.value.trim() || undefined,
+      tags: normaliseTags(tagsInput.value),
+      featured: featuredInput.checked
+    };
+    const file = imageInput.files && imageInput.files[0];
+
+    disableForm(true);
+    setFormStatus('Saving…', 'info');
+
+    try {
+      if (editingId){
+        await updateItem(editingId, payload);
+        if (file){
+          const uploadMeta = await requestUpload(editingId, file);
+          await uploadImage(uploadMeta.uploadUrl, file);
+          await updateItem(editingId, { imageKey: uploadMeta.objectKey, imageAlt: payload.title });
+        }
+        await loadItems(false);
+        const updated = items.find(i => i.id === editingId);
+        if (updated){
+          setEditing(updated);
+        }
+        setFormStatus('Project updated.', 'success');
+      } else {
+        const created = await createItem(payload);
+        const item = created.item || created;
+        if (file && item && item.id){
+          const uploadMeta = await requestUpload(item.id, file);
+          await uploadImage(uploadMeta.uploadUrl, file);
+          await updateItem(item.id, { imageKey: uploadMeta.objectKey, imageAlt: payload.title });
+        }
+        await loadItems(false);
+        setEditing(null);
+        setFormStatus('Project created.', 'success');
+      }
+    } catch (err) {
+      console.error(err);
+      setFormStatus(err.message || 'Save failed.', 'error');
+    } finally {
+      disableForm(false);
+      imageInput.value = '';
+    }
+  }
+
+  function handleListClick(event){
+    const button = event.target.closest('button');
+    if (!button || !button.dataset.action) return;
+    const card = button.closest('.item-card');
+    if (!card) return;
+    const id = card.dataset.id;
+    const item = items.find(i => i.id === id);
+    if (!item) return;
+
+    if (button.dataset.action === 'edit'){
+      setEditing(item);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } else if (button.dataset.action === 'delete'){
+      if (!confirm('Delete this project? This will remove it from the public site.')) return;
+      disableForm(true);
+      setFormStatus('Deleting…', 'warning');
+      deleteItem(id)
+        .then(() => loadItems(false))
+        .then(() => {
+          if (editingId === id) setEditing(null);
+          setFormStatus('Project deleted.', 'success');
+        })
+        .catch(err => {
+          console.error(err);
+          setFormStatus(err.message || 'Delete failed.', 'error');
+        })
+        .finally(() => disableForm(false));
+    }
+  }
+
+  function handleReset(){
+    setEditing(null);
+    setFormStatus('', 'info');
+  }
+
+  function init(){
+    if (!form) return;
+    form.addEventListener('submit', handleSubmit);
+    if (listEl) listEl.addEventListener('click', handleListClick);
+    if (resetBtn) resetBtn.addEventListener('click', handleReset);
+    if (refreshBtn) refreshBtn.addEventListener('click', () => loadItems(true));
+    if (API_BASE) {
+      loadItems(false);
+    } else if (configWarning) {
+      configWarning.hidden = false;
+    }
+    if (!ADMIN_KEY){
+      setFormStatus('Warning: window.PORTFOLIO_ADMIN_KEY is not set; secured endpoints may reject requests.', 'warning');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/src/index.html
+++ b/src/index.html
@@ -123,7 +123,13 @@
     .proj{padding:16px; border:1px solid var(--rule); border-radius:14px}
     .proj h3{margin:.2rem 0 .2rem}
     .proj p{margin:.2rem 0 .5rem; color:var(--muted)}
+    .proj-tags{margin:.35rem 0 .4rem; color:var(--muted); font-size:.9rem; font-weight:600; letter-spacing:.01em}
     .proj a{color:inherit}
+    .proj figure{margin:0 0 .75rem; border-radius:12px; overflow:hidden; border:1px solid var(--rule); background:rgba(15,24,48,.35)}
+    .proj figure img{display:block; width:100%; height:200px; object-fit:cover}
+
+    .projects-status{margin:.4rem 0 .8rem; color:var(--muted)}
+    .projects-status.error{color:#f87171}
 
     /* Blog */
     .blog{padding: clamp(20px, 4vw, 32px)}
@@ -256,7 +262,7 @@
       <!-- PROJECTS PAGE -->
       <section id="projects" class="view projects" aria-labelledby="h-proj">
         <h2 id="h-proj">Projects</h2>
-        <div class="grid">
+        <div class="grid" id="projects-grid">
           <article class="proj">
             <h3>Cloud Cost Guard</h3>
             <p>Dashboard + alerts for non‑prod AWS cost spikes and mis‑tagged resources.</p>
@@ -402,6 +408,84 @@
       window.__ensureCvLoaded = function(){
         return load().catch(() => {});
       };
+    })();
+
+    // Projects loader — fetch dynamic portfolio items when the API is configured
+    (function(){
+      const container = document.querySelector('#projects .grid');
+      if (!container) return;
+
+      const API_BASE = (window.PORTFOLIO_API_BASE || '').trim().replace(/\/+$/, '');
+      const MEDIA_BASE = (window.PORTFOLIO_MEDIA_BASE || '').trim().replace(/\/+$/, '');
+
+      if (!API_BASE) {
+        console.info('Portfolio API base URL not configured; using static project list.');
+        return;
+      }
+
+      const fallbackMarkup = container.innerHTML;
+      const status = document.createElement('p');
+      status.className = 'projects-status';
+      status.textContent = 'Loading projects…';
+      container.innerHTML = '';
+      container.appendChild(status);
+
+      const headers = { 'Accept': 'application/json' };
+
+      function resolveImage(item){
+        if (!item) return '';
+        if (item.imageUrl) return item.imageUrl;
+        if (item.imageKey && MEDIA_BASE) {
+          return `${MEDIA_BASE}/${item.imageKey}`;
+        }
+        return item.imageKey || '';
+      }
+
+      function render(items){
+        if (!Array.isArray(items) || !items.length){
+          status.textContent = 'No portfolio items published yet.';
+          return;
+        }
+        const markup = items.map(item => {
+          const image = resolveImage(item);
+          const link = item.link || item.href || '';
+          const summary = item.summary || item.description || '';
+          const title = item.title || 'Untitled';
+          const imageAlt = item.imageAlt || `${title} preview`;
+          const tags = Array.isArray(item.tags) ? item.tags.filter(Boolean) : [];
+          const tagMarkup = tags.length ? `<p class="proj-tags">${tags.map(t => `#${t}`).join(' ')}</p>` : '';
+          const figure = image ? `<figure><img src="${image}" alt="${imageAlt}"></figure>` : '';
+          const linkMarkup = link ? `<a href="${link}" target="_blank" rel="noopener">View →</a>` : '';
+          const safeSummary = summary ? `<p>${summary}</p>` : '';
+          return `<article class="proj">${figure}<h3>${title}</h3>${safeSummary}${tagMarkup}${linkMarkup}</article>`;
+        }).join('');
+        container.innerHTML = markup;
+      }
+
+      function showFallback(message){
+        container.innerHTML = '';
+        if (message){
+          const error = document.createElement('p');
+          error.className = 'projects-status error';
+          error.textContent = message;
+          container.appendChild(error);
+        }
+        container.insertAdjacentHTML('beforeend', fallbackMarkup);
+      }
+
+      fetch(`${API_BASE}/items`, { headers })
+        .then(res => {
+          if (!res.ok) throw new Error(`Failed to load projects (${res.status})`);
+          return res.json();
+        })
+        .then(payload => {
+          const items = Array.isArray(payload) ? payload : (payload.items || []);
+          render(items);
+        })
+        .catch(err => {
+          console.error(err);
+          showFallback('Unable to load projects from the API. Showing static list instead.');
+        });
     })();
 
     // Blog posts loader — fetch latest Medium entries


### PR DESCRIPTION
## Summary
- add an admin dashboard that supports creating, editing, deleting, and uploading images for portfolio projects
- load portfolio projects dynamically on the public site whenever an API endpoint is configured
- add an AWS SAM infrastructure stack (API Gateway, Lambda, DynamoDB, S3) to back the admin dashboard

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e373fe506083228b371de679d233c3